### PR TITLE
Unlock getConnInfo in dev

### DIFF
--- a/examples/node/simple/app/server.ts
+++ b/examples/node/simple/app/server.ts
@@ -1,4 +1,19 @@
+import { getConnInfo } from "@hono/node-server/conninfo";
+import { createMiddleware } from "hono/factory";
 import { createHonoServer } from "react-router-hono-server/node";
 
 console.log("loading server");
-export default await createHonoServer();
+
+const localNetwork = createMiddleware(async (c, next) => {
+  const info = getConnInfo(c);
+  console.log("localNetwork", info);
+  console.log(`Remote address is ${info.remote.address}`);
+
+  await next();
+});
+
+export default await createHonoServer({
+  configure(app) {
+    app.use(localNetwork);
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-hono-server",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "description": "The Vite plugin you need to create a Hono server for your React Router app in less than 10 seconds.",
   "exports": {

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -5,7 +5,12 @@ import { createMiddleware } from "hono/factory";
 import { logger } from "hono/logger";
 import type { BlankEnv } from "hono/types";
 import { type ServerBuild, createRequestHandler } from "react-router";
-import { cleanUpgradeListeners, createWebSocket, patchUpgradeListener } from "../helpers";
+import {
+  bindIncomingRequestSocketInfo,
+  cleanUpgradeListeners,
+  createWebSocket,
+  patchUpgradeListener,
+} from "../helpers";
 import { cache } from "../middleware";
 import type { HonoServerOptionsBase, WithWebsocket, WithoutWebsocket } from "../types/hono-server-options-base";
 
@@ -56,6 +61,10 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
     app,
     enabled: mergedOptions.useWebSocket ?? false,
   });
+
+  if (!PRODUCTION) {
+    app.use(bindIncomingRequestSocketInfo());
+  }
 
   /**
    * Serve assets files from build/client/assets

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -3,6 +3,7 @@ import { createMiddleware } from "hono/factory";
 import { logger } from "hono/logger";
 import type { BlankEnv } from "hono/types";
 import { type ServerBuild, createRequestHandler } from "react-router";
+import { bindIncomingRequestSocketInfo } from "../helpers";
 import { cache } from "../middleware";
 import type { HonoServerOptionsBase, WithoutWebsocket } from "../types/hono-server-options-base";
 
@@ -31,6 +32,7 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
   if (DEV) {
     const { serveStatic } = await import("@hono/node-server/serve-static");
     app.use("*", cache(60 * 60), serveStatic({ root: "./public" })); // 1 hour
+    app.use(bindIncomingRequestSocketInfo());
   }
 
   /**

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -6,7 +6,12 @@ import { createMiddleware } from "hono/factory";
 import { logger } from "hono/logger";
 import type { BlankEnv } from "hono/types";
 import { type ServerBuild, createRequestHandler } from "react-router";
-import { cleanUpgradeListeners, createWebSocket, patchUpgradeListener } from "../helpers";
+import {
+  bindIncomingRequestSocketInfo,
+  cleanUpgradeListeners,
+  createWebSocket,
+  patchUpgradeListener,
+} from "../helpers";
 import { cache } from "../middleware";
 import type { HonoServerOptionsBase, WithWebsocket, WithoutWebsocket } from "../types/hono-server-options-base";
 import type { CreateNodeServerOptions } from "../types/node.https";
@@ -71,6 +76,10 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
     app,
     enabled: mergedOptions.useWebSocket ?? false,
   });
+
+  if (!PRODUCTION) {
+    app.use(bindIncomingRequestSocketInfo());
+  }
 
   /**
    * Serve assets files from build/client/assets


### PR DESCRIPTION
Fixes #40 

Add a way to use `getConnInfo` in dev.

https://hono.dev/docs/helpers/conninfo
