### PR TITLE
fix dev server file exclusion regex

### DIFF
--- a/examples/node/custom-mount/app/routes/sub.tsx
+++ b/examples/node/custom-mount/app/routes/sub.tsx
@@ -37,6 +37,7 @@ export default function Index({ loaderData: data }: Route.ComponentProps) {
       </button>
       <input />
       <Input value={value} onChange={(e) => setValue(e.target.value)} />
+      <img src="/images/database.svg" alt="Database2" className="w-10" />
       <div className="mt-8 w-full max-w-4xl overflow-x-auto">
         <table className="w-full border-collapse bg-gray-100 shadow-md rounded-lg">
           <thead>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-hono-server",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "type": "module",
   "description": "The Vite plugin you need to create a Hono server for your React Router app in less than 10 seconds.",
   "exports": {

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -163,7 +163,9 @@ export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOption
         entry: pluginConfig.serverEntryPoint,
         export: "default",
         exclude: [
-          /.*\.(ts|js|tsx|jsx|css|svg)(\?.*)?$/,
+          new RegExp(
+            `^(?=\\/${pluginConfig.appDirectory.replaceAll("/", "")}\\/)((?!.*\\.data(\\?|$)).*\\..*(\\\?.*)?$)`
+          ),
           /\?import(\?.*)?$/,
           /^\/@.+$/,
           /^\/node_modules\/.*/,


### PR DESCRIPTION
Fixes #54 

Dev only:

It should let the Hono server handle `/public` assets, and Vite handle all other files, except requests for `.data`.