### PR TITLE
update dev plugin exclude regex to also parse backslashes

### DIFF
--- a/src/dev.ts
+++ b/src/dev.ts
@@ -273,12 +273,12 @@ export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOption
         export: options.dev?.export || "default",
         exclude: [
           new RegExp(
-            `^(?=\\/${pluginConfig.appDirectory.replace(/^\/+|\/+$/g, "").replaceAll("/", "\\/")}\\/)((?!.*\\.data(\\?|$)).*\\..*(\\?.*)?$)`
+            `^(?=\\/${pluginConfig.appDirectory.replace(/^[/\\]+|[/\\]+$/g, "").replaceAll(/[/\\]+/g, "/")}\\/)((?!.*\\.data(\\?|$)).*\\..*(\\?.*)?$)`
           ),
           /\?import(\?.*)?$/,
           /^\/@.+$/,
           /^\/node_modules\/.*/,
-          `/${pluginConfig.appDirectory}/**/.*/**`,
+          `^(?=\\/${pluginConfig.appDirectory.replace(/^[/\\]+|[/\\]+$/g, "").replace(/[/\\]+/g, "/")}/**/.*/**)`,
           ...(pluginConfig.dev?.exclude || []),
         ],
       });


### PR DESCRIPTION
# Description
Fix: #111 

This PR updates the `exclude` regexes to support backslashes that are passed when the dev server is running on Windows, aiming to fix 404 errors when using a custom appDir.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required