### PR TITLE
[FIX] Prerender fails without exporting routeDiscovery.

### DIFF
--- a/src/dev.ts
+++ b/src/dev.ts
@@ -72,7 +72,7 @@ type ReactRouterHonoServerPluginOptions =
 const REACT_ROUTER_VIRTUAL_MODULE_ID = "\0virtual:react-router/server-build";
 const VIRTUAL_MODULE_ID = "\0virtual:react-router-hono-server/server";
 const REACT_ROUTER_EXPORT =
-  "export { serverManifest as assets, assetsBuildDirectory, basename, entry, future, isSpaMode, prerender, publicPath, routes, ssr };";
+  "export { serverManifest as assets, assetsBuildDirectory, basename, entry, future, isSpaMode, prerender, publicPath, routes, ssr, routeDiscovery };";
 
 export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOptions = {}): Plugin {
   const runtime: Runtime = options.runtime || "node";


### PR DESCRIPTION
Fixes # Build Failure when setting prerender option

# Description

This change fixes a bug in the plugin that was not exporting routeDiscovery along side other necessary exports. this may constrict the comptability of this plugin to versions of react-router that may include routeDiscovery as a new option. as of react-router@7.6.{0,1} this addition was necessary

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Manual fix successfully run against react-router@7.6.0/7.6.1 

- [ ] Integration tests
- [ ] Unit tests
- [X] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [X] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [X] Additional checks (document below if any)

# Questions (if appropriate):
Not sure what happens with react-router version that do not introduce routeDiscovery this particular fix may not be backwards compatibile without a dummy variable for older react-router versions.
