### PR TITLE
Remove production-only remark from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,8 +567,6 @@ export interface HonoServerOptions<E extends Env = BlankEnv> extends HonoServerO
   /**
    * Callback executed just after `serve` from `@hono/node-server`
    *
-   * **Only applied to production mode**
-   *
    * For example, you can use this to bind `@hono/node-ws`'s `injectWebSocket`
    */
   onServe?: (server: ServerType) => void;


### PR DESCRIPTION
# Description

I am using `onServe` to run Socket.IO in development mode so it seems this production warning is outdated.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [X] Documentation
