### PR TITLE
Support Vite v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@react-router/dev": "^7.2.0",
     "miniflare": "^3.20241205.0",
     "react-router": "^7.2.0",
-    "vite": "^6.0.0",
+    "vite": "^6.0.0 || ^7.0.0",
     "wrangler": "^4.2.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^7.2.0
         version: 7.5.0(react@19.1.0)
       vite:
-        specifier: ^6.0.0
+        specifier: ^6.0.0 || ^7.0.0
         version: 6.2.5(@types/node@22.14.0)
       wrangler:
         specifier: ^4.2.0


### PR DESCRIPTION
Fixes consuming apps complaining about peer dependencies as react-router-hono-server currently only supports Vite v6.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

Installed vite@7.0.4 in an app using react-router-hono-server. Everything seemed fine. 🤷 

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [ ] Check if the code is well documented
- [x] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
