### PR TITLE
Don't override existing cache header

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,7 @@ export function cache(seconds: number) {
 
     await next();
 
-    if (!c.res.ok) {
+    if (!c.res.ok || c.res.headers.has("cache-control")) {
       return;
     }
 


### PR DESCRIPTION
Fixes #

# Description

React router (remix) supports returning a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). In the response we can set headers, in this case, cache control headers. But the current implementation preemptively overrides the cache control header. This PR checks if the cache control header exists before setting it.

The cache middleware uses a simple check if something looks like `<name>.<extension>` to determine whether to apply the cache header. But in our project, we have a route that looks like `manifest[.]webmanifest.tsx` which maps to the path `manifest.webmanifest` and we don't want this cached (for some reason).

We set the cache-control header in the response but gets overridden.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

I used a built version in the project and works as expected.

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
