### PR TITLE
Statically import RR build.

### DIFF
--- a/.changeset/small-parks-help.md
+++ b/.changeset/small-parks-help.md
@@ -1,0 +1,5 @@
+---
+"react-router-hono-server": patch
+---
+
+Statically import RR build

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -1,3 +1,5 @@
+// @ts-expect-error - Virtual module provided by React Router at build time
+import * as build from "virtual:react-router/server-build";
 import type { Serve, ServeOptions } from "bun";
 import { type Env, Hono } from "hono";
 import { serveStatic } from "hono/bun";
@@ -13,7 +15,6 @@ import {
   createGetLoadContext,
   createWebSocket,
   getBuildMode,
-  importBuild,
   patchUpgradeListener,
 } from "../helpers";
 import { cache } from "../middleware";
@@ -70,7 +71,6 @@ export async function createHonoServer<E extends Env = BlankEnv>(
   options?: HonoServerOptionsWithWebSocket<E>
 ): Promise<CustomBunServer>;
 export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoServerOptions<E>) {
-  const build = await importBuild();
   const basename = import.meta.env.REACT_ROUTER_HONO_SERVER_BASENAME;
   const mergedOptions: HonoServerOptions<E> = {
     ...options,

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,4 +1,6 @@
 import type { AddressInfo } from "node:net";
+// @ts-expect-error - Virtual module provided by React Router at build time
+import * as build from "virtual:react-router/server-build";
 import { type ServerType, serve } from "@hono/node-server";
 import { type ServeStaticOptions, serveStatic } from "@hono/node-server/serve-static";
 import { type Env, Hono } from "hono";
@@ -6,14 +8,12 @@ import { createMiddleware } from "hono/factory";
 import { logger } from "hono/logger";
 import type { BlankEnv } from "hono/types";
 import { createRequestHandler } from "react-router";
-
 import {
   bindIncomingRequestSocketInfo,
   cleanUpgradeListeners,
   createGetLoadContext,
   createWebSocket,
   getBuildMode,
-  importBuild,
   patchUpgradeListener,
 } from "../helpers";
 import { cache } from "../middleware";
@@ -97,7 +97,6 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
   if (!options?.listeningListener) {
     console.time("🏎️ Server started in");
   }
-  const build = await importBuild();
   const basename = import.meta.env.REACT_ROUTER_HONO_SERVER_BASENAME;
   const mergedOptions: HonoServerOptions<E> = {
     ...options,


### PR DESCRIPTION
# Description

This is an experiment to reduce RR build import time.

In my own project, using a Node 22 Alpine image, a server bundle of 300KB can take 15 seconds to load (~3s on local mahcine) 🤯