### PR TITLE
fix: add compatibility with Vite Environment API promoted to v8

### DIFF
--- a/.changeset/fine-bats-visit.md
+++ b/.changeset/fine-bats-visit.md
@@ -1,0 +1,5 @@
+---
+"react-router-hono-server": patch
+---
+
+Add compatibility with environment API being promoted to v8 instead of unstable in React Router

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -104,12 +104,18 @@ export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOption
         return;
       }
 
+      const isEnvironmentApiEnabled =
+        pluginConfig.future.unstable_viteEnvironmentApi ??
+        (pluginConfig.future as { v8_viteEnvironmentApi?: boolean }).v8_viteEnvironmentApi;
+
+      const flagName = pluginConfig.future.unstable_viteEnvironmentApi
+        ? "unstable_viteEnvironmentApi"
+        : "v8_viteEnvironmentApi";
+
       const serverEntryPoint = pluginConfig.serverEntryPoint;
 
-      if (pluginConfig.future.unstable_viteEnvironmentApi) {
-        console.warn(
-          "\x1b[33mThe unstable_viteEnvironmentApi is enabled.\nThis is experimental and may break your build.\x1b[0m\n"
-        );
+      if (isEnvironmentApiEnabled) {
+        console.warn(`\x1b[33mThe ${flagName} is enabled.\nThis is experimental and may break your build.\x1b[0m\n`);
       }
 
       if (
@@ -140,7 +146,7 @@ export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOption
         },
       } satisfies UserConfig;
 
-      if (!pluginConfig.future.unstable_viteEnvironmentApi && !pluginConfig.isSsrBuild) {
+      if (!isEnvironmentApiEnabled && !pluginConfig.isSsrBuild) {
         return baseConfig;
       }
 
@@ -160,9 +166,9 @@ export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOption
         };
       }
 
-      if (runtime === "bun" && pluginConfig.future.unstable_viteEnvironmentApi) {
+      if (runtime === "bun" && isEnvironmentApiEnabled) {
         throw new Error(
-          "The unstable_viteEnvironmentApi is not supported with the Bun runtime. Please disable it in your react-router.config.ts"
+          `The ${flagName} is not supported with the Bun runtime. Please disable it in your react-router.config.ts`
         );
       }
 
@@ -215,7 +221,7 @@ export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOption
         },
       } satisfies Omit<UserConfig, "plugins">;
 
-      if (pluginConfig.future.unstable_viteEnvironmentApi) {
+      if (isEnvironmentApiEnabled) {
         return {
           ...baseConfig,
           environments: {


### PR DESCRIPTION
Fixes https://github.com/rphlmr/react-router-hono-server/issues/170

# Description

Currently, in code the flag that's being checked is `unstable_viteEnvironmentApi`, however in one of recent RR updates it got promoted to `v8_viteEnvironmentApi`. This made it mandatory to rename the field in config when upgrading version, which caused the plugin to not work properly. This PR fixes this, while still providing compatibility with the previous version.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

I patched the version locally to make sure that's what causing issues with deploy and then decided to upstream the fix 😄 

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [ ] Check if the code is well documented
- [x] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
