### PR TITLE
chore: 🔨 Update hono and related dependencies. Make hono a peer dep

### DIFF
--- a/.changeset/few-rules-deny.md
+++ b/.changeset/few-rules-deny.md
@@ -1,0 +1,5 @@
+---
+"react-router-hono-server": patch
+---
+
+chore: 🔨 Update hono and related dependencies. Make hono a peer dep

--- a/package.json
+++ b/package.json
@@ -95,16 +95,16 @@
     "@drizzle-team/brocli": "0.11.0",
     "@hono/node-server": "1.19.9",
     "@hono/node-ws": "1.3.0",
-    "@hono/vite-dev-server": "0.24.1",
-    "hono": "4.11.7"
+    "@hono/vite-dev-server": "0.25.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.1",
     "@changesets/cli": "^2.29.8",
     "@cloudflare/workers-types": "^4.20250405.0",
     "@types/bun": "^1.3.6",
-    "@types/node": "^22.19.7",
+    "@types/node": "^22.19.10",
     "@vitest/coverage-v8": "^4.0.18",
+    "hono": "4.11.9",
     "lefthook": "^2.0.16",
     "npm-run-all": "^4.1.5",
     "tsup": "^8.5.1",
@@ -116,6 +116,7 @@
     "@hono/node-server": "^1.19.0",
     "@react-router/dev": "^7.9.0",
     "@types/react": "^19.0.0",
+    "hono": "^4.11.0",
     "miniflare": "^3.20241205.0",
     "react-router": "^7.9.0",
     "vite": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,22 +13,19 @@ importers:
         version: 0.11.0
       '@hono/node-server':
         specifier: 1.19.9
-        version: 1.19.9(hono@4.11.7)
+        version: 1.19.9(hono@4.11.9)
       '@hono/node-ws':
         specifier: 1.3.0
-        version: 1.3.0(@hono/node-server@1.19.9(hono@4.11.7))(hono@4.11.7)
+        version: 1.3.0(@hono/node-server@1.19.9(hono@4.11.9))(hono@4.11.9)
       '@hono/vite-dev-server':
-        specifier: 0.24.1
-        version: 0.24.1(hono@4.11.7)(miniflare@3.20250718.2)(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))
+        specifier: 0.25.0
+        version: 0.25.0(hono@4.11.9)(miniflare@3.20250718.2)(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))
       '@react-router/dev':
         specifier: ^7.9.0
-        version: 7.9.4(@types/node@22.19.7)(react-router@7.9.4(react@19.2.0))(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.7))(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))
+        version: 7.9.4(@types/node@22.19.10)(react-router@7.9.4(react@19.2.0))(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.10))(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.2
-      hono:
-        specifier: 4.11.7
-        version: 4.11.7
       miniflare:
         specifier: ^3.20241205.0
         version: 3.20250718.2
@@ -37,7 +34,7 @@ importers:
         version: 7.9.4(react@19.2.0)
       vite:
         specifier: ^7.0.0
-        version: 7.1.12(@types/node@22.19.7)
+        version: 7.1.12(@types/node@22.19.10)
       wrangler:
         specifier: ^4.2.0
         version: 4.45.0(@cloudflare/workers-types@4.20251014.0)
@@ -47,7 +44,7 @@ importers:
         version: 2.3.1
       '@changesets/cli':
         specifier: ^2.29.8
-        version: 2.29.8(@types/node@22.19.7)
+        version: 2.29.8(@types/node@22.19.10)
       '@cloudflare/workers-types':
         specifier: ^4.20250405.0
         version: 4.20251014.0
@@ -55,11 +52,14 @@ importers:
         specifier: ^1.3.6
         version: 1.3.6
       '@types/node':
-        specifier: ^22.19.7
-        version: 22.19.7
+        specifier: ^22.19.10
+        version: 22.19.10
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@22.19.7))
+        version: 4.0.18(vitest@4.0.18(@types/node@22.19.10))
+      hono:
+        specifier: 4.11.9
+        version: 4.11.9
       lefthook:
         specifier: ^2.0.16
         version: 2.0.16
@@ -74,7 +74,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.7)
+        version: 4.0.18(@types/node@22.19.10)
 
 packages:
 
@@ -888,8 +888,8 @@ packages:
       '@hono/node-server': ^1.19.2
       hono: ^4.6.0
 
-  '@hono/vite-dev-server@0.24.1':
-    resolution: {integrity: sha512-1ga1v9awRuYgs/C2/nhnOiAUeB3zPI/rEbfXkow7kOSHa8AYxxveDSpVsMZneE3ojwgkXQl2G68S+xj2WqxWPw==}
+  '@hono/vite-dev-server@0.25.0':
+    resolution: {integrity: sha512-4j5rs7yUTOObU2/yCEHeWbf3C8m95SD9lhdUUE6CJ462Emp9vS94yiza2dsA8+ly5pdaIQW0cd4nhNVcwYL5tA==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: '*'
@@ -1253,8 +1253,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.19.7':
-    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+  '@types/node@22.19.10':
+    resolution: {integrity: sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==}
 
   '@types/react@19.2.2':
     resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
@@ -1806,8 +1806,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.11.7:
-    resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
+  hono@4.11.9:
+    resolution: {integrity: sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -3235,7 +3235,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.8(@types/node@22.19.7)':
+  '@changesets/cli@2.29.8(@types/node@22.19.10)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -3251,7 +3251,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.2(@types/node@22.19.7)
+      '@inquirer/external-editor': 1.0.2(@types/node@22.19.10)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -3636,23 +3636,23 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@hono/node-server@1.19.9(hono@4.11.7)':
+  '@hono/node-server@1.19.9(hono@4.11.9)':
     dependencies:
-      hono: 4.11.7
+      hono: 4.11.9
 
-  '@hono/node-ws@1.3.0(@hono/node-server@1.19.9(hono@4.11.7))(hono@4.11.7)':
+  '@hono/node-ws@1.3.0(@hono/node-server@1.19.9(hono@4.11.9))(hono@4.11.9)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.7)
-      hono: 4.11.7
+      '@hono/node-server': 1.19.9(hono@4.11.9)
+      hono: 4.11.9
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@hono/vite-dev-server@0.24.1(hono@4.11.7)(miniflare@3.20250718.2)(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))':
+  '@hono/vite-dev-server@0.25.0(hono@4.11.9)(miniflare@3.20250718.2)(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.7)
-      hono: 4.11.7
+      '@hono/node-server': 1.19.9(hono@4.11.9)
+      hono: 4.11.9
       minimatch: 9.0.5
     optionalDependencies:
       miniflare: 3.20250718.2
@@ -3733,12 +3733,12 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.2(@types/node@22.19.7)':
+  '@inquirer/external-editor@1.0.2(@types/node@22.19.10)':
     dependencies:
       chardet: 2.1.0
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 22.19.7
+      '@types/node': 22.19.10
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3847,7 +3847,7 @@ snapshots:
 
   '@poppinss/exception@1.2.2': {}
 
-  '@react-router/dev@7.9.4(@types/node@22.19.7)(react-router@7.9.4(react@19.2.0))(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.7))(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))':
+  '@react-router/dev@7.9.4(@types/node@22.19.10)(react-router@7.9.4(react@19.2.0))(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.10))(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
@@ -3876,8 +3876,8 @@ snapshots:
       semver: 7.7.3
       tinyglobby: 0.2.15
       valibot: 1.1.0(typescript@5.9.3)
-      vite: 7.1.12(@types/node@22.19.7)
-      vite-node: 3.2.4(@types/node@22.19.7)
+      vite: 7.1.12(@types/node@22.19.10)
+      vite-node: 3.2.4(@types/node@22.19.10)
     optionalDependencies:
       typescript: 5.9.3
       wrangler: 4.45.0(@cloudflare/workers-types@4.20251014.0)
@@ -3993,7 +3993,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.19.7':
+  '@types/node@22.19.10':
     dependencies:
       undici-types: 6.21.0
 
@@ -4001,7 +4001,7 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@22.19.7))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@22.19.10))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -4013,7 +4013,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.19.7)
+      vitest: 4.0.18(@types/node@22.19.10)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -4024,13 +4024,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.1.12(@types/node@22.19.7))':
+  '@vitest/mocker@4.0.18(vite@7.1.12(@types/node@22.19.10))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.1.12(@types/node@22.19.7)
+      vite: 7.1.12(@types/node@22.19.10)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -4163,7 +4163,7 @@ snapshots:
 
   bun-types@1.3.6:
     dependencies:
-      '@types/node': 22.19.7
+      '@types/node': 22.19.10
 
   bundle-require@5.1.0(esbuild@0.27.2):
     dependencies:
@@ -4676,7 +4676,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.11.7: {}
+  hono@4.11.9: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -5697,13 +5697,13 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-node@3.2.4(@types/node@22.19.7):
+  vite-node@3.2.4(@types/node@22.19.10):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.12(@types/node@22.19.7)
+      vite: 7.1.12(@types/node@22.19.10)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5718,7 +5718,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.12(@types/node@22.19.7):
+  vite@7.1.12(@types/node@22.19.10):
     dependencies:
       esbuild: 0.25.11
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5727,13 +5727,13 @@ snapshots:
       rollup: 4.52.5
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.7
+      '@types/node': 22.19.10
       fsevents: 2.3.3
 
-  vitest@4.0.18(@types/node@22.19.7):
+  vitest@4.0.18(@types/node@22.19.10):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.1.12(@types/node@22.19.7))
+      '@vitest/mocker': 4.0.18(vite@7.1.12(@types/node@22.19.10))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -5750,10 +5750,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.1.12(@types/node@22.19.7)
+      vite: 7.1.12(@types/node@22.19.10)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.7
+      '@types/node': 22.19.10
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Changelog (from `main`)

### [Unreleased] - 2026-02-10

#### Changed
- Updated Hono-related dependencies:
  - `@hono/vite-dev-server`: `0.24.1` -> `0.25.0`
  - `hono`: `4.11.7` -> `4.11.9` (moved from direct dependency to dev dependency for local tooling)
- Updated `@types/node`: `^22.19.7` -> `^22.19.10`.
- Added `hono` as a peer dependency: `^4.11.0`.

#### Metadata
- Added changeset for patch release: `.changeset/few-rules-deny.md`
- Commit: `72763f0` (`chore: 🔨 Update hono and related dependencies. Make hono a peer dep`)
