### PR TITLE
feat: ✨ support independent Vite base routing

### DIFF
--- a/.changeset/honest-bases-route.md
+++ b/.changeset/honest-bases-route.md
@@ -1,0 +1,31 @@
+---
+"react-router-hono-server": patch
+---
+
+## Summary
+
+- Support independent React Router `basename` and Vite `base` URL spaces across development and production.
+- Route generated JavaScript and CSS assets according to Vite’s base while preserving document, route-data, and public-directory URL ownership.
+
+## What's changed
+
+### Vite base routing
+
+- **Development server:** Propagate Vite’s configured `base` through the plugin environment and scope Hono’s module, dependency, and asset exclusions to the Vite pathname prefix, including absolute and full-URL bases.
+- **Node, Bun, and Deno adapters:** Serve generated assets beneath an absolute pathname base and strip that prefix before resolving files, while preserving user-provided asset rewrite callbacks.
+- **Cloudflare adapter:** Match generated assets under an absolute Vite base and remove the pathname prefix before forwarding requests to the asset binding.
+- **Shared path handling:** Add classification and normalization for root, absolute, full-URL, and relative Vite bases. Full-URL and relative bases remain externally/Vite-owned rather than creating a fixed server-side mount.
+- **Documentation and release metadata:** Document independent `basename`/`base` configuration, runtime-specific asset ownership, and the patch release covering the fix.
+
+## Compatibility
+
+- React Router’s `basename` continues to control documents, route data, and the handler independently from Vite-generated URLs.
+- Root-relative behavior remains unchanged; relative bases (`""` and `"./"`) preserve Vite-emitted URLs, and public-directory files remain served from the origin root.
+- AWS production continues to leave generated assets externally owned.
+
+## Test coverage
+
+- Added unit coverage for Vite base classification, generated-asset route mapping, prefix stripping, and composition with adapter rewrite callbacks.
+- Added integration coverage across development, Node/Bun/Deno production, Cloudflare asset bindings, AWS production, nested and root document basenames, full-URL bases, and relative bases.
+- Updated development-plugin tests and fixture preparation to exercise Vite base configuration and generated CSS/asset URLs.
+

--- a/README.md
+++ b/README.md
@@ -766,6 +766,27 @@ export default {
 
 React Router also accepts `basename`, `appDirectory`, and `buildDirectory` in the same configuration file.
 
+#### React Router `basename` and Vite `base`
+
+React Router's [`basename`](https://reactrouter.com/api/framework-conventions/react-router.config.ts#basename) and Vite's [`base`](https://vite.dev/config/shared-options.html#base) configure independent URL spaces:
+
+- `basename` mounts documents, route data requests, and the React Router handler.
+- `base` controls Vite development URLs and URLs emitted for generated JavaScript, CSS, and other bundled assets.
+
+For an application deployed entirely beneath `/v2`, configure both upstream tools:
+
+```ts
+// react-router.config.ts
+export default { basename: "/v2" };
+
+// vite.config.ts
+export default defineConfig({ base: "/v2/", plugins: [reactRouterHonoServer(), reactRouter()] });
+```
+
+The prefixes may intentionally differ. For example, `basename: "/v2/app"` with `base: "/v2/"` keeps application documents beneath `/v2/app` while generated assets remain beneath `/v2/assets`. Likewise, `basename: "/"` with `base: "/v2/"` keeps documents at the origin root and moves only Vite-owned URLs.
+
+The Node, Bun, and Deno adapters serve generated assets locally when `base` is an absolute pathname. Cloudflare Workers passes the original asset URL to its asset binding, and AWS production expects an external asset service. Full-URL bases remain externally owned. Relative bases (`""` and `"./"`) are preserved as emitted by Vite and do not create a fixed server-side mount. Public-directory files always remain available from the origin root rather than beneath `base`.
+
 #### Deployment behavior
 
 | Configuration                | Node, Bun, Deno, and Cloudflare Workers                                                   | AWS Lambda                                                                                                              |

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -23,6 +23,11 @@ import {
 } from "../helpers";
 import { cache } from "../middleware";
 import { isReactRouterBuildRequest } from "../react-router-build-request";
+import {
+  classifyVitePublicPath,
+  composeViteAssetRewriteRequestPath,
+  viteGeneratedAssetsRoute,
+} from "../vite-public-path";
 
 export { createGetLoadContext };
 
@@ -103,6 +108,7 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
   const mode = getBuildMode();
   const PRODUCTION = mode === "production";
   const clientBuildPath = `${import.meta.env.REACT_ROUTER_HONO_SERVER_BUILD_DIRECTORY}/client`;
+  const vitePublicPath = classifyVitePublicPath(import.meta.env.REACT_ROUTER_HONO_SERVER_VITE_BASE);
 
   // Store the shutdown callback for use in shutdown()
   if (PRODUCTION && mergedOptions.onGracefulShutdown) {
@@ -129,12 +135,18 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
    */
   if (!isReactRouterBuildRequest()) {
     const { serveStatic } = await import("hono/bun");
+    const rewriteClientAssetsPath: NonNullable<ServeStaticOptions<E>["rewriteRequestPath"]> =
+      composeViteAssetRewriteRequestPath(
+        vitePublicPath,
+        mergedOptions.serveStaticOptions?.clientAssets?.rewriteRequestPath,
+      );
     app.use(
-      `/${import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR}/*`,
+      viteGeneratedAssetsRoute(vitePublicPath, import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR),
       cache(60 * 60 * 24 * 365), // 1 year
       serveStatic({
         root: clientBuildPath,
         ...mergedOptions.serveStaticOptions?.clientAssets,
+        rewriteRequestPath: rewriteClientAssetsPath,
       }),
     );
 

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -22,6 +22,12 @@ import {
   importBuild,
 } from "../helpers";
 import { cache } from "../middleware";
+import {
+  classifyVitePublicPath,
+  stripVitePathnamePrefix,
+  type VitePublicPath,
+  viteGeneratedAssetsRoute,
+} from "../vite-public-path";
 
 export { createGetLoadContext };
 
@@ -61,6 +67,7 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
   };
   const mode = getBuildMode();
   const PRODUCTION = mode === "production";
+  const vitePublicPath = classifyVitePublicPath(import.meta.env.REACT_ROUTER_HONO_SERVER_VITE_BASE);
   const app = new Hono<E>(mergedOptions.app);
   const { upgradeWebSocket } = await createWebSocket({
     app,
@@ -77,9 +84,9 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
    */
   app.use(
     // https://developers.cloudflare.com/workers/static-assets/binding/#experimental_serve_directly
-    `/${import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR}/*`,
+    viteGeneratedAssetsRoute(vitePublicPath, import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR),
     cache(60 * 60 * 24 * 365), // 1 year
-    serveCloudflareAssets(),
+    serveCloudflareAssets(vitePublicPath),
   );
 
   /**
@@ -165,7 +172,7 @@ let warned = false;
  *
  * https://github.com/sergiodxa/remix-hono/blob/main/src/cloudflare.ts
  */
-function serveCloudflareAssets() {
+function serveCloudflareAssets(vitePublicPath?: VitePublicPath) {
   return createMiddleware(async (c, next) => {
     const binding = c.env?.ASSETS as Fetcher | undefined;
 
@@ -182,8 +189,12 @@ function serveCloudflareAssets() {
     let response: Response;
 
     try {
+      const url = new URL(c.req.url);
+      if (vitePublicPath) {
+        url.pathname = stripVitePathnamePrefix(url.pathname, vitePublicPath);
+      }
       response = (await binding.fetch(
-        c.req.url,
+        url.toString(),
         c.req.raw.clone() as unknown as RequestInit,
       )) as unknown as globalThis.Response;
     } catch {

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -23,6 +23,11 @@ import {
 } from "../helpers";
 import { cache } from "../middleware";
 import { isReactRouterBuildRequest } from "../react-router-build-request";
+import {
+  classifyVitePublicPath,
+  composeViteAssetRewriteRequestPath,
+  viteGeneratedAssetsRoute,
+} from "../vite-public-path";
 
 export { createGetLoadContext };
 
@@ -101,6 +106,7 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
   const mode = getBuildMode();
   const PRODUCTION = mode === "production";
   const clientBuildPath = `${import.meta.env.REACT_ROUTER_HONO_SERVER_BUILD_DIRECTORY}/client`;
+  const vitePublicPath = classifyVitePublicPath(import.meta.env.REACT_ROUTER_HONO_SERVER_VITE_BASE);
   const app = new Hono<E>(mergedOptions.app);
   const { upgradeWebSocket, injectWebSocket } = await createWebSocket({
     app,
@@ -124,10 +130,19 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
    */
   if (!isReactRouterBuildRequest()) {
     const { serveStatic } = await import("hono/deno");
+    const rewriteClientAssetsPath: NonNullable<ServeStaticOptions<E>["rewriteRequestPath"]> =
+      composeViteAssetRewriteRequestPath(
+        vitePublicPath,
+        mergedOptions.serveStaticOptions?.clientAssets?.rewriteRequestPath,
+      );
     app.use(
-      `/${import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR}/*`,
+      viteGeneratedAssetsRoute(vitePublicPath, import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR),
       cache(60 * 60 * 24 * 365), // 1 year
-      serveStatic({ root: clientBuildPath, ...mergedOptions.serveStaticOptions?.clientAssets }),
+      serveStatic({
+        root: clientBuildPath,
+        ...mergedOptions.serveStaticOptions?.clientAssets,
+        rewriteRequestPath: rewriteClientAssetsPath,
+      }),
     );
 
     /**

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -28,6 +28,11 @@ import {
 } from "../helpers";
 import { cache } from "../middleware";
 import { isReactRouterBuildRequest } from "../react-router-build-request";
+import {
+  classifyVitePublicPath,
+  composeViteAssetRewriteRequestPath,
+  viteGeneratedAssetsRoute,
+} from "../vite-public-path";
 
 export { createGetLoadContext };
 
@@ -141,6 +146,7 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
   const mode = getBuildMode();
   const PRODUCTION = mode === "production";
   const clientBuildPath = `${import.meta.env.REACT_ROUTER_HONO_SERVER_BUILD_DIRECTORY}/client`;
+  const vitePublicPath = classifyVitePublicPath(import.meta.env.REACT_ROUTER_HONO_SERVER_VITE_BASE);
   const app = new Hono<E>(mergedOptions.app);
   const { upgradeWebSocket, injectWebSocket, nodeWebSocket } = await createWebSocket({
     app,
@@ -159,10 +165,19 @@ export async function createHonoServer<E extends Env = BlankEnv>(options?: HonoS
   /**
    * Serve assets files from build/client/assets
    */
+  const rewriteClientAssetsPath: NonNullable<ServeStaticOptions<E>["rewriteRequestPath"]> =
+    composeViteAssetRewriteRequestPath(
+      vitePublicPath,
+      mergedOptions.serveStaticOptions?.clientAssets?.rewriteRequestPath,
+    );
   app.use(
-    `/${import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR}/*`,
+    viteGeneratedAssetsRoute(vitePublicPath, import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR),
     cache(60 * 60 * 24 * 365), // 1 year
-    serveStatic({ root: clientBuildPath, ...mergedOptions.serveStaticOptions?.clientAssets }),
+    serveStatic({
+      root: clientBuildPath,
+      ...mergedOptions.serveStaticOptions?.clientAssets,
+      rewriteRequestPath: rewriteClientAssetsPath,
+    }),
   );
 
   /**

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -12,6 +12,7 @@ import { pathToFileURL } from "node:url";
 import type { Runtime } from "./types/runtime";
 
 import { isReactRouterBuildRequest } from "./react-router-build-request";
+import { classifyVitePublicPath, vitePathnamePrefix } from "./vite-public-path";
 
 type MetaEnv<T> = {
   [K in keyof T as `import.meta.env.${string & K}`]: T[K];
@@ -127,6 +128,9 @@ export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOption
           "import.meta.env.REACT_ROUTER_HONO_SERVER_RUNTIME": JSON.stringify(runtime),
           "import.meta.env.REACT_ROUTER_HONO_SERVER_BASENAME": JSON.stringify(
             pluginConfig.basename,
+          ),
+          "import.meta.env.REACT_ROUTER_HONO_SERVER_VITE_BASE": JSON.stringify(
+            pluginConfig.viteBase,
           ),
         } satisfies MetaEnv<ReactRouterHonoServerEnv>,
         ssr: {
@@ -276,33 +280,30 @@ export function reactRouterHonoServer(options: ReactRouterHonoServerPluginOption
       }
 
       // Create and apply the Hono dev server plugin
+      const vitePrefix = vitePathnamePrefix(classifyVitePublicPath(pluginConfig.viteBase));
+      const appDirectory = pluginConfig.appDirectory
+        .replace(/^[/\\]+|[/\\]+$/g, "")
+        .replaceAll(/[/\\]+/g, "/");
+      const sourceDirectory = appDirectory.split("/")[0];
+      const appPath = `${vitePrefix}/${appDirectory}`;
+      const sourcePath = `${vitePrefix}/${sourceDirectory}`;
+      const escapedAppPath = escapeRegExp(appPath);
+      const escapedSourcePath = escapeRegExp(sourcePath);
+      const escapedVitePrefix = escapeRegExp(vitePrefix);
+
       devServerPlugin = honoDevServer({
         adapter,
         injectClientScript: false,
         entry: pluginConfig.serverEntryPoint,
         export: options.dev?.export || "default",
         exclude: [
-          new RegExp(
-            `^(?=\\/${pluginConfig.appDirectory.replace(/^[/\\]+|[/\\]+$/g, "").replaceAll(/[/\\]+/g, "/")}\\/)((?!.*\\.data(\\?|$)).*\\..*(\\?.*)?$)`,
-          ),
-          new RegExp(
-            `^(?=\\/${
-              pluginConfig.appDirectory
-                .replace(/^[/\\]+|[/\\]+$/g, "")
-                .replaceAll(/[/\\]+/g, "/")
-                .split("/")[0]
-            }\\/)((?!.*\\.data(\\?|$)).*\\..*(\\?.*)?$)`,
-          ),
+          new RegExp(`^(?=${escapedAppPath}\\/)((?!.*\\.data(\\?|$)).*\\..*(\\?.*)?$)`),
+          new RegExp(`^(?=${escapedSourcePath}\\/)((?!.*\\.data(\\?|$)).*\\..*(\\?.*)?$)`),
           /\?import(\?.*)?$/,
-          /^\/@.+$/,
-          /^\/node_modules\/.*/,
-          `^(?=\\/${pluginConfig.appDirectory.replace(/^[/\\]+|[/\\]+$/g, "").replace(/[/\\]+/g, "/")}/**/.*/**)`,
-          `^(?=\\/${
-            pluginConfig.appDirectory
-              .replace(/^[/\\]+|[/\\]+$/g, "")
-              .replace(/[/\\]+/g, "/")
-              .split("/")[0]
-          }/**/.*/**)`,
+          new RegExp(`^${escapedVitePrefix}\\/@.+$`),
+          new RegExp(`^${escapedVitePrefix}\\/node_modules\\/.*`),
+          `^(?=${appPath}/**/.*/**)`,
+          `^(?=${sourcePath}/**/.*/**)`,
           ...(pluginConfig.dev?.exclude || []),
         ],
       });
@@ -404,6 +405,7 @@ function resolvePluginConfig(config: UserConfig, options: ReactRouterHonoServerP
   const serverEntryPoint = options.serverEntryPoint || findDefaultServerEntry(appDirectory);
   const serverBuildFile = reactRouterConfig.serverBuildFile;
   const basename = reactRouterConfig.basename;
+  const viteBase = config.base ?? "/";
 
   return {
     rootDirectory,
@@ -415,12 +417,17 @@ function resolvePluginConfig(config: UserConfig, options: ReactRouterHonoServerP
     dev: options.dev,
     serverBuildFile,
     basename,
+    viteBase,
   };
 }
 
 type PluginConfig = ReturnType<typeof resolvePluginConfig>;
 
 let warned = false;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function findDefaultServerEntry(appDirectory: string): string {
   const fileWay = `${appDirectory}/server.ts`;

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -3,6 +3,7 @@ interface ReactRouterHonoServerEnv {
   readonly REACT_ROUTER_HONO_SERVER_ASSETS_DIR: string;
   readonly REACT_ROUTER_HONO_SERVER_RUNTIME: string;
   readonly REACT_ROUTER_HONO_SERVER_BASENAME: string;
+  readonly REACT_ROUTER_HONO_SERVER_VITE_BASE: string;
 }
 
 interface ImportMetaEnv extends ReactRouterHonoServerEnv {}

--- a/src/vite-public-path.ts
+++ b/src/vite-public-path.ts
@@ -1,0 +1,67 @@
+export type VitePublicPath =
+  | { kind: "root"; raw: string; pathname: "/" }
+  | { kind: "absolute"; raw: string; pathname: string }
+  | { kind: "url"; raw: string; pathname: string }
+  | { kind: "relative"; raw: string; pathname: "/" };
+
+export function classifyVitePublicPath(raw: string): VitePublicPath {
+  if (raw === "" || raw === "./") {
+    return { kind: "relative", raw, pathname: "/" };
+  }
+
+  if (raw.startsWith("/")) {
+    const pathname = normalizeAbsolutePathname(raw);
+    return pathname === "/" ? { kind: "root", raw, pathname } : { kind: "absolute", raw, pathname };
+  }
+
+  try {
+    const url = new URL(raw);
+    return { kind: "url", raw, pathname: normalizeAbsolutePathname(url.pathname) };
+  } catch {
+    return { kind: "relative", raw, pathname: "/" };
+  }
+}
+
+export function vitePathnamePrefix(publicPath: VitePublicPath): string {
+  return publicPath.pathname === "/" ? "" : publicPath.pathname.slice(0, -1);
+}
+
+export function viteGeneratedAssetsRoute(publicPath: VitePublicPath, assetsDir: string): string {
+  const localPrefix = publicPath.kind === "absolute" ? vitePathnamePrefix(publicPath) : "";
+  return `${localPrefix}/${assetsDir.replace(/^\/+|\/+$/g, "")}/*`;
+}
+
+export function stripVitePathnamePrefix(pathname: string, publicPath: VitePublicPath): string {
+  if (publicPath.kind !== "absolute" || publicPath.pathname === "/") {
+    return pathname;
+  }
+
+  const prefix = vitePathnamePrefix(publicPath);
+  if (pathname === prefix) return "/";
+  if (pathname.startsWith(`${prefix}/`)) return pathname.slice(prefix.length);
+  return pathname;
+}
+
+export function composeViteAssetRewriteRequestPath(
+  publicPath: VitePublicPath,
+  userRewrite?: (path: string) => string,
+): (path: string) => string;
+export function composeViteAssetRewriteRequestPath<Context>(
+  publicPath: VitePublicPath,
+  userRewrite?: (path: string, context: Context) => string,
+): (path: string, context: Context) => string;
+export function composeViteAssetRewriteRequestPath<Context>(
+  publicPath: VitePublicPath,
+  userRewrite?: (path: string, context?: Context) => string,
+) {
+  return (requestPath: string, context?: Context) => {
+    const logicalPath = stripVitePathnamePrefix(requestPath, publicPath);
+    if (!userRewrite) return logicalPath;
+    return context === undefined ? userRewrite(logicalPath) : userRewrite(logicalPath, context);
+  };
+}
+
+function normalizeAbsolutePathname(pathname: string): string {
+  const withLeadingSlash = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  return withLeadingSlash === "/" ? "/" : `${withLeadingSlash.replace(/\/+$/, "")}/`;
+}

--- a/tests/fixtures/basic/app/generated.css
+++ b/tests/fixtures/basic/app/generated.css
@@ -1,0 +1,3 @@
+html {
+  text-rendering: optimizeLegibility;
+}

--- a/tests/fixtures/basic/app/root.tsx
+++ b/tests/fixtures/basic/app/root.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 
+import "./generated.css";
+
 export const links = () => [{ rel: "stylesheet", href: "/fixture.css" }];
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/tests/fixtures/vite-base-full-url/react-router.config.ts
+++ b/tests/fixtures/vite-base-full-url/react-router.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from "@react-router/dev/config";
+
+export default { ssr: true } satisfies Config;

--- a/tests/fixtures/vite-base-nested-documents/react-router.config.ts
+++ b/tests/fixtures/vite-base-nested-documents/react-router.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  basename: "/v2/app",
+  ssr: true,
+} satisfies Config;

--- a/tests/fixtures/vite-base-relative-dot/react-router.config.ts
+++ b/tests/fixtures/vite-base-relative-dot/react-router.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from "@react-router/dev/config";
+
+export default { ssr: true } satisfies Config;

--- a/tests/fixtures/vite-base-relative-empty/react-router.config.ts
+++ b/tests/fixtures/vite-base-relative-empty/react-router.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from "@react-router/dev/config";
+
+export default { ssr: true } satisfies Config;

--- a/tests/fixtures/vite-base-root-documents/react-router.config.ts
+++ b/tests/fixtures/vite-base-root-documents/react-router.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  basename: "/",
+  ssr: true,
+} satisfies Config;

--- a/tests/fixtures/vite-base-same-prefix/react-router.config.ts
+++ b/tests/fixtures/vite-base-same-prefix/react-router.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  basename: "/v2/",
+  ssr: true,
+} satisfies Config;

--- a/tests/helpers/fixture.ts
+++ b/tests/helpers/fixture.ts
@@ -19,7 +19,15 @@ const REPO_ROOT = path.resolve(fileURLToPath(new URL("../..", import.meta.url)))
 const SKIP_COPY_DIRS = new Set(["node_modules", "build", ".react-router"]);
 const ARTIFACT_DIRECTORY = path.join(REPO_ROOT, "out", "test-artifacts");
 
-export type FixtureName = "basic" | "prerendered";
+export type FixtureName =
+  | "basic"
+  | "prerendered"
+  | "vite-base-root-documents"
+  | "vite-base-same-prefix"
+  | "vite-base-nested-documents"
+  | "vite-base-full-url"
+  | "vite-base-relative-empty"
+  | "vite-base-relative-dot";
 
 export class FixtureApp {
   readonly name: FixtureName;
@@ -156,6 +164,19 @@ async function createPreparedFixture(name: FixtureName, runtime: RuntimeName) {
       await cp(path.join(REPO_ROOT, "tests/fixtures/overlays", runtime), cwd, { recursive: true });
     }
 
+    const viteBase = viteBaseForFixture(name);
+    if (viteBase !== undefined) {
+      const viteConfigPath = path.join(cwd, "vite.config.ts");
+      const viteConfig = await readFile(viteConfigPath, "utf8");
+      await writeFile(
+        viteConfigPath,
+        viteConfig.replace(
+          "defineConfig({",
+          `defineConfig({\n  base: ${JSON.stringify(viteBase)},`,
+        ),
+      );
+    }
+
     const launcher = getLauncher(runtime);
     const artifact = await findPackageArtifact();
     let packageSource = artifact;
@@ -199,6 +220,24 @@ async function createPreparedFixture(name: FixtureName, runtime: RuntimeName) {
   } catch (error) {
     await rm(cwd, { recursive: true, force: true });
     throw error;
+  }
+}
+
+function viteBaseForFixture(name: FixtureName): string | undefined {
+  switch (name) {
+    case "vite-base-root-documents":
+    case "vite-base-same-prefix":
+    case "vite-base-nested-documents":
+      return "/v2/";
+    case "vite-base-full-url":
+      return "https://cdn.example.com/v2/";
+    case "vite-base-relative-empty":
+      return "";
+    case "vite-base-relative-dot":
+      return "./";
+    case "basic":
+    case "prerendered":
+      return undefined;
   }
 }
 

--- a/tests/integration/bun.prerender.test.ts
+++ b/tests/integration/bun.prerender.test.ts
@@ -23,9 +23,9 @@ test("serves callback documents statically and falls back to runtime SSR", async
   const response = await fixture.app.fetch("/loader");
   expect(response.status).toBe(200);
   expect(response.headers.get("content-length")).toBe(
-    String(Buffer.byteLength(fixture.callback.loaderHtml)),
+    String(Buffer.byteLength(fixture.withoutBasename.callback.loaderHtml)),
   );
-  expect(await response.text()).toBe(fixture.callback.loaderHtml);
+  expect(await response.text()).toBe(fixture.withoutBasename.callback.loaderHtml);
 
   const rootResponse = await fixture.app.fetch("/");
   expect(rootResponse.status).toBe(200);

--- a/tests/integration/cloudflare.prerender.test.ts
+++ b/tests/integration/cloudflare.prerender.test.ts
@@ -20,7 +20,7 @@ registerPrerenderBuildTests(() => fixture);
 test("serves callback documents statically and falls back to runtime SSR", async () => {
   const response = await fixture.app.fetch("/loader");
   expect(response.status).toBe(200);
-  expect(await response.text()).toBe(fixture.callback.loaderHtml);
+  expect(await response.text()).toBe(fixture.withoutBasename.callback.loaderHtml);
 
   const rootResponse = await fixture.app.fetch("/");
   expect(rootResponse.status).toBe(200);

--- a/tests/integration/contract/prerender.ts
+++ b/tests/integration/contract/prerender.ts
@@ -5,56 +5,7 @@ import type { RuntimeName } from "../../helpers/launchers";
 
 import { type FixtureApp, ProductionFixture } from "../../helpers/fixture";
 
-const ALL_PRERENDER_CONFIG = `import type { Config } from "@react-router/dev/config";
-
-export default {
-  ssr: true,
-  prerender: true,
-} satisfies Config;
-`;
-
-const CUSTOM_LAYOUT_CONFIG = `import type { Config } from "@react-router/dev/config";
-
-export default {
-  ssr: true,
-  basename: "/base",
-  appDirectory: "custom-app",
-  buildDirectory: "output",
-  prerender: ["/"],
-} satisfies Config;
-`;
-
-const SELECTED_PRERENDER_CONFIG = `import type { Config } from "@react-router/dev/config";
-
-export default {
-  ssr: true,
-  prerender: ["/", "/post/example"],
-} satisfies Config;
-`;
-
-const CALLBACK_PRERENDER_CONFIG = `import type { Config } from "@react-router/dev/config";
-
-export default {
-  ssr: true,
-  prerender: {
-    paths: async () => ["/loader"],
-    concurrency: 2,
-  },
-} satisfies Config;
-`;
-
-const SPA_PRERENDER_CONFIG = `import type { Config } from "@react-router/dev/config";
-
-export default {
-  ssr: false,
-  buildDirectory: "spa-build",
-  prerender: ["/", "/loader", "/post/example"],
-} satisfies Config;
-`;
-
-export type PrerenderFixture = {
-  app: FixtureApp;
-  customLayout: { rootHtml: string };
+type PrerenderVariant = {
   all: { rootHtml: string; loaderHtml: string; loaderData: string; dynamicHtmlMissing: boolean };
   selected: {
     rootHtml: string;
@@ -67,68 +18,48 @@ export type PrerenderFixture = {
   callback: { loaderHtml: string; loaderData: string; rootHtmlMissing: boolean };
 };
 
+export type PrerenderFixture = {
+  app: FixtureApp;
+  withoutBasename: PrerenderVariant;
+  withBasename: PrerenderVariant;
+};
+
 export async function preparePrerenderFixture(runtime: RuntimeName): Promise<PrerenderFixture> {
   const app = await ProductionFixture.create("prerendered", runtime);
 
   await cp(path.join(app.cwd, "app"), path.join(app.cwd, "custom-app"), { recursive: true });
-  await app.edit("react-router.config.ts", CUSTOM_LAYOUT_CONFIG);
-  await app.build();
-  const customLayout = {
-    rootHtml: await app.read("output/client/base/index.html"),
-  };
 
-  await app.edit("react-router.config.ts", ALL_PRERENDER_CONFIG);
-  await app.build();
-  const all = {
-    rootHtml: await app.read("build/client/index.html"),
-    loaderHtml: await app.read("build/client/loader/index.html"),
-    loaderData: await app.read("build/client/loader.data"),
-    dynamicHtmlMissing: await isMissing(app, "build/client/post/example/index.html"),
-  };
+  const withBasename = await preparePrerenderVariant(app, {
+    basename: "/base/",
+    appDirectory: "custom-app",
+    buildDirectory: "output",
+    spaBuildDirectory: "spa-output",
+  });
+  // Keep the root callback build last because the runtime assertions start this build.
+  const withoutBasename = await preparePrerenderVariant(app, {
+    buildDirectory: "build",
+    spaBuildDirectory: "spa-build",
+  });
 
-  await app.edit("react-router.config.ts", SELECTED_PRERENDER_CONFIG);
-  await app.build();
-  const selected = {
-    rootHtml: await app.read("build/client/index.html"),
-    dynamicHtml: await app.read("build/client/post/example/index.html"),
-    dynamicData: await app.read("build/client/post/example.data"),
-    loaderHtmlMissing: await isMissing(app, "build/client/loader/index.html"),
-    loaderDataMissing: await isMissing(app, "build/client/loader.data"),
-  };
-
-  await app.edit("react-router.config.ts", SPA_PRERENDER_CONFIG);
-  await app.build();
-  const spa = {
-    rootHtml: await app.read("spa-build/client/index.html"),
-    fallbackHtml: await app.read("spa-build/client/__spa-fallback.html"),
-  };
-
-  await app.edit("react-router.config.ts", CALLBACK_PRERENDER_CONFIG);
-  await app.build();
-  const callback = {
-    loaderHtml: await app.read("build/client/loader/index.html"),
-    loaderData: await app.read("build/client/loader.data"),
-    rootHtmlMissing: await isMissing(app, "build/client/index.html"),
-  };
-
-  return { app, customLayout, all, selected, spa, callback };
+  return { app, withoutBasename, withBasename };
 }
 
 export function registerPrerenderBuildTests(getFixture: () => PrerenderFixture) {
-  test("honors basename and custom application and build directories", () => {
-    expect(getFixture().customLayout.rootHtml).toContain("SSR works");
-  });
+  const variants = [
+    { label: "without basename", key: "withoutBasename" },
+    { label: "with basename", key: "withBasename" },
+  ] as const;
 
-  test("prerenders every static route", () => {
-    const { all } = getFixture();
+  test.each(variants)("prerenders every static route $label", ({ key }) => {
+    const { all } = getFixture()[key];
     expect(all.rootHtml).toContain("SSR works");
     expect(all.loaderHtml).toContain("hello-from-loader");
     expect(all.loaderData).toContain("hello-from-loader");
     expect(all.dynamicHtmlMissing).toBe(true);
   });
 
-  test("prerenders only an explicit array of routes", () => {
-    const { selected } = getFixture();
+  test.each(variants)("prerenders only an explicit array of routes $label", ({ key }) => {
+    const { selected } = getFixture()[key];
     expect(selected.rootHtml).toContain("SSR works");
     expect(selected.dynamicHtml).toContain("example");
     expect(selected.dynamicData).toContain("example");
@@ -136,18 +67,108 @@ export function registerPrerenderBuildTests(getFixture: () => PrerenderFixture) 
     expect(selected.loaderDataMissing).toBe(true);
   });
 
-  test("resolves routes from an async callback", () => {
-    const { callback } = getFixture();
+  test.each(variants)("resolves routes from an async callback $label", ({ key }) => {
+    const { callback } = getFixture()[key];
     expect(callback.loaderHtml).toContain("hello-from-loader");
     expect(callback.loaderData).toContain("hello-from-loader");
     expect(callback.rootHtmlMissing).toBe(true);
   });
 
-  test("generates static documents and a SPA fallback when SSR is disabled", () => {
-    const { spa } = getFixture();
-    expect(spa.rootHtml).toContain("SSR works");
-    expect(spa.fallbackHtml).toContain("<html");
-  });
+  test.each(variants)(
+    "generates static documents and a SPA fallback when SSR is disabled $label",
+    ({ key }) => {
+      const { spa } = getFixture()[key];
+      expect(spa.rootHtml).toContain("SSR works");
+      expect(spa.fallbackHtml).toContain("<html");
+    },
+  );
+}
+
+async function preparePrerenderVariant(
+  app: FixtureApp,
+  options: {
+    basename?: string;
+    appDirectory?: string;
+    buildDirectory: string;
+    spaBuildDirectory: string;
+  },
+): Promise<PrerenderVariant> {
+  const documentPrefix = options.basename ? `${options.basename.replace(/^\/+|\/+$/g, "")}/` : "";
+  const clientDirectory = `${options.buildDirectory}/client/${documentPrefix}`;
+
+  await app.edit("react-router.config.ts", createConfig(options, { ssr: true, prerender: "true" }));
+  await app.build();
+  const all = {
+    rootHtml: await app.read(`${clientDirectory}index.html`),
+    loaderHtml: await app.read(`${clientDirectory}loader/index.html`),
+    loaderData: await app.read(`${clientDirectory}loader.data`),
+    dynamicHtmlMissing: await isMissing(app, `${clientDirectory}post/example/index.html`),
+  };
+
+  await app.edit(
+    "react-router.config.ts",
+    createConfig(options, { ssr: true, prerender: '["/", "/post/example"]' }),
+  );
+  await app.build();
+  const selected = {
+    rootHtml: await app.read(`${clientDirectory}index.html`),
+    dynamicHtml: await app.read(`${clientDirectory}post/example/index.html`),
+    dynamicData: await app.read(`${clientDirectory}post/example.data`),
+    loaderHtmlMissing: await isMissing(app, `${clientDirectory}loader/index.html`),
+    loaderDataMissing: await isMissing(app, `${clientDirectory}loader.data`),
+  };
+
+  await app.edit(
+    "react-router.config.ts",
+    createConfig(
+      { ...options, buildDirectory: options.spaBuildDirectory },
+      { ssr: false, prerender: '["/", "/loader", "/post/example"]' },
+    ),
+  );
+  await app.build();
+  const spa = {
+    rootHtml: await app.read(`${options.spaBuildDirectory}/client/${documentPrefix}index.html`),
+    fallbackHtml: await app.read(
+      `${options.spaBuildDirectory}/client/${options.basename ? "index.html" : "__spa-fallback.html"}`,
+    ),
+  };
+
+  await app.edit(
+    "react-router.config.ts",
+    createConfig(options, {
+      ssr: true,
+      prerender: '{ paths: async () => ["/loader"], concurrency: 2 }',
+    }),
+  );
+  await app.build();
+  const callback = {
+    loaderHtml: await app.read(`${clientDirectory}loader/index.html`),
+    loaderData: await app.read(`${clientDirectory}loader.data`),
+    rootHtmlMissing: await isMissing(app, `${clientDirectory}index.html`),
+  };
+
+  return { all, selected, spa, callback };
+}
+
+function createConfig(
+  options: { basename?: string; appDirectory?: string; buildDirectory: string },
+  config: { ssr: boolean; prerender: string },
+) {
+  const optionalConfig = [
+    options.basename ? `  basename: ${JSON.stringify(options.basename)},` : undefined,
+    options.appDirectory ? `  appDirectory: ${JSON.stringify(options.appDirectory)},` : undefined,
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+
+  return `import type { Config } from "@react-router/dev/config";
+
+export default {
+  ssr: ${config.ssr},
+${optionalConfig ? `${optionalConfig}\n` : ""}  buildDirectory: ${JSON.stringify(options.buildDirectory)},
+  prerender: ${config.prerender},
+} satisfies Config;
+`;
 }
 
 async function isMissing(app: FixtureApp, relativePath: string) {

--- a/tests/integration/deno.prerender.test.ts
+++ b/tests/integration/deno.prerender.test.ts
@@ -22,7 +22,7 @@ registerPrerenderBuildTests(() => fixture);
 test("serves callback documents statically and falls back to runtime SSR", async () => {
   const response = await fixture.app.fetch("/loader");
   expect(response.status).toBe(200);
-  expect(await response.text()).toBe(fixture.callback.loaderHtml);
+  expect(await response.text()).toBe(fixture.withoutBasename.callback.loaderHtml);
 
   const rootResponse = await fixture.app.fetch("/");
   expect(rootResponse.status).toBe(200);

--- a/tests/integration/node.prerender.test.ts
+++ b/tests/integration/node.prerender.test.ts
@@ -22,8 +22,10 @@ test("serves callback documents statically and falls back to runtime SSR", async
   const contentLength = response.headers.get("content-length");
 
   expect(response.status).toBe(200);
-  expect(contentLength).toBe(String(Buffer.byteLength(fixture.callback.loaderHtml)));
-  expect(await response.text()).toBe(fixture.callback.loaderHtml);
+  expect(contentLength).toBe(
+    String(Buffer.byteLength(fixture.withoutBasename.callback.loaderHtml)),
+  );
+  expect(await response.text()).toBe(fixture.withoutBasename.callback.loaderHtml);
 
   const rootResponse = await fixture.app.fetch("/");
   expect(rootResponse.status).toBe(200);

--- a/tests/integration/vite-base.test.ts
+++ b/tests/integration/vite-base.test.ts
@@ -1,0 +1,172 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, describe, expect, test } from "vite-plus/test";
+
+import type { FixtureName } from "../helpers/fixture";
+import type { RuntimeName } from "../helpers/launchers";
+
+import { ProductionFixture, type FixtureApp } from "../helpers/fixture";
+import { assertProductionBrowserBehavior } from "./contract/browser";
+
+const apps: FixtureApp[] = [];
+
+afterAll(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.stop()));
+});
+
+async function startProduction(name: FixtureName, runtime: RuntimeName = "node") {
+  const app = await ProductionFixture.create(name, runtime);
+  apps.push(app);
+  const build = await app.build();
+  expect(build.exitCode, build.stderr || build.stdout).toBe(0);
+  await app.startProduction();
+  return app;
+}
+
+function generatedAssetUrls(html: string) {
+  return [...html.matchAll(/(?:src|href)="([^"]+)"/g)]
+    .map((match) => match[1])
+    .filter((url) => /(?:^|\/)assets\//.test(url));
+}
+
+async function expectLocalGeneratedAssets(app: FixtureApp, documentPath: string, prefix: string) {
+  const response = await app.fetch(documentPath);
+  expect(response.status).toBe(200);
+  const html = await response.text();
+  const assetUrls = generatedAssetUrls(html).filter((url) => url.startsWith(prefix));
+  expect(assetUrls.some((url) => url.endsWith(".js"))).toBe(true);
+  expect(assetUrls.some((url) => url.endsWith(".css"))).toBe(true);
+  for (const url of assetUrls) {
+    expect((await app.fetch(url)).status, url).toBe(200);
+  }
+  return html;
+}
+
+describe("Vite base and React Router basename ownership", () => {
+  test("keeps root documents separate from a /v2/ Vite base in development", async () => {
+    const app = await ProductionFixture.create("vite-base-root-documents", "node");
+    apps.push(app);
+    await app.startDev();
+
+    const response = await app.fetch("/");
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('"/v2/app/root.tsx"');
+    expect((await app.fetch("/v2/@vite/client")).status).toBe(200);
+    expect((await app.fetch("/api/health")).status).toBe(200);
+    expect(app.logs()).not.toContain('No route matches URL "/v2/');
+  });
+
+  test("serves generated production assets under /v2/ while documents remain at root", async () => {
+    const app = await startProduction("vite-base-root-documents");
+    await expectLocalGeneratedAssets(app, "/", "/v2/assets/");
+    expect((await app.fetch("/fixture.txt")).status).toBe(200);
+    expect((await app.fetch("/v2/assets/missing.js")).status).toBe(404);
+    await assertProductionBrowserBehavior(app);
+  });
+
+  test.each(["node", "bun", "deno"] as const)(
+    "serves documents, data, and absolute-base assets on %s",
+    async (runtime) => {
+      const app = await startProduction("vite-base-same-prefix", runtime);
+      await expectLocalGeneratedAssets(app, "/v2/", "/v2/assets/");
+      expect((await app.fetch("/v2/loader.data")).status).toBe(200);
+      expect((await app.fetch("/fixture.txt")).status).toBe(200);
+      expect((await app.fetch("/v2/fixture.txt")).status).toBe(404);
+      expect((await app.fetch("/v20/assets/missing.js")).status).toBe(404);
+    },
+  );
+
+  test("does not conflate a shared Vite prefix with a nested document basename", async () => {
+    const app = await startProduction("vite-base-nested-documents");
+    await expectLocalGeneratedAssets(app, "/v2/app/", "/v2/assets/");
+    expect((await app.fetch("/v2/app/loader.data")).status).toBe(200);
+    expect((await app.fetch("/v2/loader")).status).toBe(404);
+  });
+
+  test("keeps Cloudflare asset-binding ownership with an absolute Vite base", async () => {
+    const app = await startProduction("vite-base-same-prefix", "cloudflare");
+    await expectLocalGeneratedAssets(app, "/v2/", "/v2/assets/");
+  });
+
+  test("keeps generated assets externally owned in AWS production", async () => {
+    const app = await ProductionFixture.create("vite-base-same-prefix", "aws");
+    apps.push(app);
+    const buildResult = await app.build();
+    expect(buildResult.exitCode, buildResult.stderr || buildResult.stdout).toBe(0);
+    const build = await import(
+      `${pathToFileURL(path.join(app.cwd, "build/server/index.js")).href}?test=${Date.now()}`
+    );
+    const handler = build.default as (
+      event: ReturnType<typeof lambdaEvent>,
+      context: ReturnType<typeof lambdaContext>,
+      callback: () => void,
+    ) => Promise<{ body: string; statusCode: number }>;
+
+    const document = await handler(lambdaEvent("/v2/"), lambdaContext(), () => {});
+    expect(document.statusCode).toBe(200);
+    const [assetUrl] = generatedAssetUrls(document.body);
+    expect(assetUrl).toMatch(/^\/v2\/assets\//);
+    const asset = await handler(lambdaEvent(assetUrl), lambdaContext(), () => {});
+    expect(asset.statusCode).toBe(404);
+  });
+
+  test.each([
+    ["vite-base-full-url", "https://cdn.example.com/v2/assets/"],
+    ["vite-base-relative-empty", "assets/"],
+    ["vite-base-relative-dot", "./assets/"],
+  ] as const)("preserves Vite-emitted URLs for %s", async (name, expectedPrefix) => {
+    const app = await startProduction(name);
+    const response = await app.fetch("/");
+    expect(response.status).toBe(200);
+    const urls = generatedAssetUrls(await response.text());
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls.every((url) => url.startsWith(expectedPrefix))).toBe(true);
+  });
+});
+
+function lambdaEvent(rawPath: string) {
+  return {
+    version: "2.0",
+    routeKey: "$default",
+    rawPath,
+    rawQueryString: "",
+    headers: { host: "example.com", "user-agent": "integration-test" },
+    requestContext: {
+      accountId: "test",
+      apiId: "test",
+      domainName: "example.com",
+      domainPrefix: "example",
+      http: {
+        method: "GET",
+        path: rawPath,
+        protocol: "HTTP/1.1",
+        sourceIp: "127.0.0.1",
+        userAgent: "test",
+      },
+      requestId: "test",
+      routeKey: "$default",
+      stage: "$default",
+      time: "",
+      timeEpoch: 0,
+    },
+    isBase64Encoded: false,
+  };
+}
+
+function lambdaContext() {
+  return {
+    callbackWaitsForEmptyEventLoop: false,
+    functionName: "test",
+    functionVersion: "$LATEST",
+    invokedFunctionArn: "test",
+    memoryLimitInMB: "128",
+    awsRequestId: "test",
+    logGroupName: "test",
+    logStreamName: "test",
+    getRemainingTimeInMillis: () => 30_000,
+    done: () => {},
+    fail: () => {},
+    succeed: () => {},
+  };
+}

--- a/tests/unit/dev.test.ts
+++ b/tests/unit/dev.test.ts
@@ -39,6 +39,7 @@ function callHook(plugin: Plugin, name: keyof Plugin, ...args: any[]) {
 function makeReactRouterConfig({
   appDirectory = "/project/app",
   assetsDir = "static",
+  base,
   basename = "/base",
   buildDirectory = "/project/build",
   rootDirectory = "/project",
@@ -46,12 +47,14 @@ function makeReactRouterConfig({
 }: {
   appDirectory?: string;
   assetsDir?: string;
+  base?: string;
   basename?: string;
   buildDirectory?: string;
   rootDirectory?: string;
   serverBuildFile?: string;
 } = {}): UserConfig {
   return {
+    base,
     build: { assetsDir },
     __reactRouterPluginContext: {
       reactRouterConfig: {
@@ -149,6 +152,7 @@ describe("reactRouterHonoServer config hook", () => {
       makeReactRouterConfig({
         appDirectory: "/workspace/src/web",
         assetsDir: "bundled-assets",
+        base: "/vite/",
         basename: "/admin",
         buildDirectory: "/workspace/output",
         rootDirectory: "/workspace",
@@ -160,6 +164,7 @@ describe("reactRouterHonoServer config hook", () => {
       "import.meta.env.REACT_ROUTER_HONO_SERVER_ASSETS_DIR": '"bundled-assets"',
       "import.meta.env.REACT_ROUTER_HONO_SERVER_RUNTIME": '"node"',
       "import.meta.env.REACT_ROUTER_HONO_SERVER_BASENAME": '"/admin"',
+      "import.meta.env.REACT_ROUTER_HONO_SERVER_VITE_BASE": '"/vite/"',
     });
     expect(result.ssr).toMatchObject({ external: [], noExternal: ["react-router-hono-server"] });
     expect(result.environments.ssr.build.rollupOptions.input).toBe("src/custom-server.ts");
@@ -343,6 +348,7 @@ describe("reactRouterHonoServer configureServer hook", () => {
       export: "development",
       injectClientScript: false,
     });
+    expect(options).not.toHaveProperty("base");
 
     const [appAssetPattern, sourceAssetPattern] = options.exclude as [RegExp, RegExp];
     expect(appAssetPattern.test("/src/web/styles.css")).toBe(true);
@@ -353,8 +359,8 @@ describe("reactRouterHonoServer configureServer hook", () => {
     expect(options.exclude).toEqual(
       expect.arrayContaining([/\?import(\?.*)?$/, /^\/@.+$/, /^\/node_modules\/.*/, customExclude]),
     );
-    expect(options.exclude).toContain("^(?=\\/src/web/**/.*/**)");
-    expect(options.exclude).toContain("^(?=\\/src/**/.*/**)");
+    expect(options.exclude).toContain("^(?=/src/web/**/.*/**)");
+    expect(options.exclude).toContain("^(?=/src/**/.*/**)");
 
     const socketMiddleware = server.middlewares.use.mock.calls[0][0];
     const request = {
@@ -373,6 +379,35 @@ describe("reactRouterHonoServer configureServer hook", () => {
     ]);
     expect(next).toHaveBeenCalledOnce();
   });
+
+  test.each(["/v2/", "https://cdn.example.com/v2/"])(
+    "prefixes only Vite-owned development exclusions with the Vite pathname from %s",
+    (base) => {
+      const customExclude = /^\/custom\.txt$/;
+      const plugin = reactRouterHonoServer({
+        dev: { exclude: [customExclude] },
+        serverEntryPoint: "app/server.ts",
+      });
+      resolvePluginConfig(plugin, makeReactRouterConfig({ appDirectory: "/project/app", base }));
+
+      callHook(plugin, "configureServer", makeServer());
+
+      const options = mocks.honoDevServer.mock.calls[0][0];
+      const excludes = options.exclude as Array<RegExp | string>;
+      const matches = (url: string) =>
+        excludes.some((exclude) => exclude instanceof RegExp && exclude.test(url));
+
+      expect(matches("/v2/app/root.tsx")).toBe(true);
+      expect(matches("/v2/@vite/client")).toBe(true);
+      expect(matches("/v2/node_modules/react/index.js")).toBe(true);
+      expect(matches("/v2/dashboard")).toBe(false);
+      expect(matches("/v2/custom-hono")).toBe(false);
+      expect(matches("/v2/app/root.data?index")).toBe(false);
+      expect(customExclude.test("/custom.txt")).toBe(true);
+      expect(customExclude.test("/v2/custom.txt")).toBe(false);
+      expect(options).not.toHaveProperty("base");
+    },
+  );
 
   test("uses unknown socket metadata fallbacks", () => {
     const plugin = reactRouterHonoServer({ serverEntryPoint: "app/server.ts" });

--- a/tests/unit/vite-public-path.test.ts
+++ b/tests/unit/vite-public-path.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+
+import {
+  classifyVitePublicPath,
+  composeViteAssetRewriteRequestPath,
+  stripVitePathnamePrefix,
+  viteGeneratedAssetsRoute,
+} from "../../src/vite-public-path";
+
+describe("Vite public path", () => {
+  test.each([
+    ["/", { kind: "root", raw: "/", pathname: "/" }],
+    ["/v2", { kind: "absolute", raw: "/v2", pathname: "/v2/" }],
+    ["/v2/", { kind: "absolute", raw: "/v2/", pathname: "/v2/" }],
+    [
+      "https://cdn.example.com/v2/",
+      { kind: "url", raw: "https://cdn.example.com/v2/", pathname: "/v2/" },
+    ],
+    ["", { kind: "relative", raw: "", pathname: "/" }],
+    ["./", { kind: "relative", raw: "./", pathname: "/" }],
+  ] as const)("classifies %j", (raw, expected) => {
+    expect(classifyVitePublicPath(raw)).toEqual(expected);
+  });
+
+  test.each([
+    ["/", "/assets/*"],
+    ["/v2", "/v2/assets/*"],
+    ["https://cdn.example.com/v2/", "/assets/*"],
+    ["", "/assets/*"],
+    ["./", "/assets/*"],
+  ])("maps generated assets for %j", (raw, expected) => {
+    expect(viteGeneratedAssetsRoute(classifyVitePublicPath(raw), "assets")).toBe(expected);
+  });
+
+  test("strips only an exact absolute Vite path segment", () => {
+    const publicPath = classifyVitePublicPath("/v2/");
+
+    expect(stripVitePathnamePrefix("/v2/assets/app.js", publicPath)).toBe("/assets/app.js");
+    expect(stripVitePathnamePrefix("/v20/assets/app.js", publicPath)).toBe("/v20/assets/app.js");
+    expect(
+      stripVitePathnamePrefix(
+        "/v2/assets/app.js",
+        classifyVitePublicPath("https://cdn.example.com/v2/"),
+      ),
+    ).toBe("/v2/assets/app.js");
+  });
+
+  test("runs the Node user rewrite after removing an absolute Vite prefix", () => {
+    const context = { runtime: "node" };
+    const userRewrite = vi.fn((requestPath: string, receivedContext: typeof context) => {
+      expect(receivedContext).toBe(context);
+      return `/rewritten${requestPath}`;
+    });
+    const rewrite = composeViteAssetRewriteRequestPath(classifyVitePublicPath("/v2/"), userRewrite);
+
+    expect(rewrite("/v2/assets/app.js", context)).toBe("/rewritten/assets/app.js");
+    expect(userRewrite).toHaveBeenCalledWith("/assets/app.js", context);
+  });
+
+  test.each(["bun", "deno"] as const)(
+    "runs the %s user rewrite after removing an absolute Vite prefix",
+    (runtime) => {
+      const userRewrite = vi.fn((requestPath: string) => `/rewritten/${runtime}${requestPath}`);
+      const rewrite = composeViteAssetRewriteRequestPath(
+        classifyVitePublicPath("/v2/"),
+        userRewrite,
+      );
+
+      expect(rewrite("/v2/assets/app.js")).toBe(`/rewritten/${runtime}/assets/app.js`);
+      expect(userRewrite).toHaveBeenCalledWith("/assets/app.js");
+    },
+  );
+
+  test("preserves root-base callback input and default rewrite behavior", () => {
+    const userRewrite = vi.fn((requestPath: string) => `/rewritten${requestPath}`);
+    const rewrite = composeViteAssetRewriteRequestPath(classifyVitePublicPath("/"), userRewrite);
+
+    expect(rewrite("/assets/app.js")).toBe("/rewritten/assets/app.js");
+    expect(userRewrite).toHaveBeenCalledWith("/assets/app.js");
+    expect(composeViteAssetRewriteRequestPath(classifyVitePublicPath("/"))("/assets/app.js")).toBe(
+      "/assets/app.js",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Support independent React Router `basename` and Vite `base` URL spaces across development and production.
- Route generated JavaScript and CSS assets according to Vite’s base while preserving document, route-data, and public-directory URL ownership.

## What's changed

### Vite base routing

- **Development server:** Propagate Vite’s configured `base` through the plugin environment and scope Hono’s module, dependency, and asset exclusions to the Vite pathname prefix, including absolute and full-URL bases.
- **Node, Bun, and Deno adapters:** Serve generated assets beneath an absolute pathname base and strip that prefix before resolving files, while preserving user-provided asset rewrite callbacks.
- **Cloudflare adapter:** Match generated assets under an absolute Vite base and remove the pathname prefix before forwarding requests to the asset binding.
- **Shared path handling:** Add classification and normalization for root, absolute, full-URL, and relative Vite bases. Full-URL and relative bases remain externally/Vite-owned rather than creating a fixed server-side mount.
- **Documentation and release metadata:** Document independent `basename`/`base` configuration, runtime-specific asset ownership, and the patch release covering the fix.

## Compatibility

- React Router’s `basename` continues to control documents, route data, and the handler independently from Vite-generated URLs.
- Root-relative behavior remains unchanged; relative bases (`""` and `"./"`) preserve Vite-emitted URLs, and public-directory files remain served from the origin root.
- AWS production continues to leave generated assets externally owned.

## Test coverage

- Added unit coverage for Vite base classification, generated-asset route mapping, prefix stripping, and composition with adapter rewrite callbacks.
- Added integration coverage across development, Node/Bun/Deno production, Cloudflare asset bindings, AWS production, nested and root document basenames, full-URL bases, and relative bases.
- Updated development-plugin tests and fixture preparation to exercise Vite base configuration and generated CSS/asset URLs.

fixes #72 #131 
