### PR TITLE
test: log nightly runtime dependency versions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -66,4 +66,11 @@ jobs:
         run: |
           vp update --latest $(node -p 'const manifest = require("./package.json"); [...Object.keys(manifest.dependencies), ...Object.keys(manifest.devDependencies)].filter((name) => name !== "typescript" && name !== "@types/node").join(" ")')
           vp add --save-dev $(node -p 'Object.entries(require("./package.json").peerDependencies).map(([name, range]) => name + "@" + range).join(" ")')
+      - name: Runtime versions
+        run: |
+          node --version
+          bun --version || true
+          deno --version || true
+          vp --version
+          vp list @hono/node-server @hono/node-ws hono vite @react-router/dev react-router ws --depth 10
       - run: vp run test:${{ matrix.runtime }}


### PR DESCRIPTION
## Summary

- log runtime tool versions in nightly runtime jobs
- log the resolved versions of the dependencies involved in the intermittent Bun/WebSocket failures
- keep test behavior unchanged: no timeout increase, retries, or launcher changes

This should make successful and failing nightly runs directly comparable before changing test infrastructure.