### PR TITLE
fix: restore nightly workflow after diagnostics change

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -72,5 +72,5 @@ jobs:
           bun --version || true
           deno --version || true
           vp --version
-          vp list @hono/node-server @hono/node-ws hono vite @react-router/dev react-router ws --depth 10
+          pnpm list @hono/node-server @hono/node-ws hono vite @react-router/dev react-router ws --depth 10
       - run: vp run test:${{ matrix.runtime }}


### PR DESCRIPTION
Fixes the diagnostics step introduced in #268.

The previous change used `vp list` with package arguments, which is not a valid invocation and caused every runtime matrix job to fail before tests ran.

This replaces it with `pnpm list`, keeping the diagnostic output while restoring the nightly test execution path.