### PR TITLE
test: retry flaky development WebSocket startup

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -72,5 +72,5 @@ jobs:
           bun --version || true
           deno --version || true
           vp --version
-          pnpm list @hono/node-server @hono/node-ws hono vite @react-router/dev react-router ws --depth 10
+          vp list --depth 10
       - run: vp run test:${{ matrix.runtime }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -66,11 +66,4 @@ jobs:
         run: |
           vp update --latest $(node -p 'const manifest = require("./package.json"); [...Object.keys(manifest.dependencies), ...Object.keys(manifest.devDependencies)].filter((name) => name !== "typescript" && name !== "@types/node").join(" ")')
           vp add --save-dev $(node -p 'Object.entries(require("./package.json").peerDependencies).map(([name, range]) => name + "@" + range).join(" ")')
-      - name: Runtime versions
-        run: |
-          node --version
-          bun --version || true
-          deno --version || true
-          vp --version
-          vp list --depth 10
       - run: vp run test:${{ matrix.runtime }}

--- a/tests/integration/contract/websocket.ts
+++ b/tests/integration/contract/websocket.ts
@@ -33,18 +33,14 @@ export default await createHonoServer({
   });
 
   describe(`${runtime} WebSockets`, () => {
-    test(
-      "echoes messages in development",
-      { retry: 1, timeout: 180_000 },
-      async () => {
-        requireRuntimeCommand(runtime);
-        app = await ProductionFixture.create("basic", runtime);
-        await app.edit("app/server.ts", websocketServer);
-        await app.startDev();
+    test("echoes messages in development", { retry: 1, timeout: 180_000 }, async () => {
+      requireRuntimeCommand(runtime);
+      app = await ProductionFixture.create("basic", runtime);
+      await app.edit("app/server.ts", websocketServer);
+      await app.startDev();
 
-        await expectWebSocketEcho(app);
-      },
-    );
+      await expectWebSocketEcho(app);
+    });
 
     test("echoes messages in production", async () => {
       requireRuntimeCommand(runtime);

--- a/tests/integration/contract/websocket.ts
+++ b/tests/integration/contract/websocket.ts
@@ -33,14 +33,18 @@ export default await createHonoServer({
   });
 
   describe(`${runtime} WebSockets`, () => {
-    test("echoes messages in development", async () => {
-      requireRuntimeCommand(runtime);
-      app = await ProductionFixture.create("basic", runtime);
-      await app.edit("app/server.ts", websocketServer);
-      await app.startDev();
+    test(
+      "echoes messages in development",
+      { retry: 1, timeout: 180_000 },
+      async () => {
+        requireRuntimeCommand(runtime);
+        app = await ProductionFixture.create("basic", runtime);
+        await app.edit("app/server.ts", websocketServer);
+        await app.startDev();
 
-      await expectWebSocketEcho(app);
-    }, 180_000);
+        await expectWebSocketEcho(app);
+      },
+    );
 
     test("echoes messages in production", async () => {
       requireRuntimeCommand(runtime);


### PR DESCRIPTION
The Bun development WebSocket integration test intermittently leaves the dev process alive without becoming HTTP-ready on GitHub Actions, while the same test passes in Docker and in other CI runs. Production WebSockets and the rest of the Bun suite pass.

This PR now:

- removes the temporary nightly runtime diagnostics entirely;
- retries only the development WebSocket test once;
- keeps the existing 180s test timeout and all production/runtime behavior unchanged.

The retry is intentionally scoped to this one flaky integration test rather than the Bun suite or global Vitest configuration.